### PR TITLE
修复IDB文件在webpack5解析需要polyfill

### DIFF
--- a/dist/IDB.js
+++ b/dist/IDB.js
@@ -19,7 +19,7 @@ var _symbol = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-sta
 
 var _promise = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/promise"));
 
-var _util = require("util");
+var _util = require("./util");
 
 var __awaiter = void 0 && (void 0).__awaiter || function (thisArg, _arguments, P, generator) {
   function adopt(value) {

--- a/es/IDB.js
+++ b/es/IDB.js
@@ -34,7 +34,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-import { isUndefined, isNull, isObject, isFunction } from 'util';
+import { isUndefined, isNull, isObject, isFunction } from './util';
 function openDB(storeName) {
     var _this = this;
     return new Promise(function (resolve) {

--- a/lib/IDB.ts
+++ b/lib/IDB.ts
@@ -1,4 +1,4 @@
-import { isUndefined, isNull, isObject, isFunction } from 'util';
+import { isUndefined, isNull, isObject, isFunction } from './util';
 
 function openDB(storeName: string): Promise<{IDB: IDBOpenDBRequest, DB: IDBDatabase | null}> {
     return new Promise((resolve) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "well-cache",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "types": "es/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
问题描述： webpack5 下解析

Did you mean './util'?
Requests that should resolve in the current directory need to start with './'.
Requests that start with a name are treated as module requests and resolve within module directories (node_modules, /Users/xxx/work/GitLabProject/xxx/node_modules).
If changing the source code is not an option there is also a resolve options called 'preferRelative' which tries to resolve these kind of requests in the current directory too.

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
	- install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "util": false }